### PR TITLE
Fixes setting test_username

### DIFF
--- a/securitybot/bot.py
+++ b/securitybot/bot.py
@@ -86,6 +86,9 @@ class SecurityBot(object):
             config_path (str): Path to configuration file
         '''
         logging.info('Creating securitybot.')
+        # username of the test user - doesn't notify this user and sets associated task as done
+        self.test_username = os.getenv('TEST_USERNAME', None)
+
         self.tasker = tasker
         self.auth_builder = auth_builder
         self.reporting_channel = reporting_channel
@@ -113,9 +116,6 @@ class SecurityBot(object):
 
         # Recover tasks
         self.recover_in_progress_tasks()
-
-        # username of the test user - doesn't notify this user and sets associated task as done
-        self.test_username = os.getenv('TEST_USERNAME', None)
 
         logging.info('Test user is "{}", who will not be notified.'.format(self.test_username))
         logging.info('Done!')


### PR DESCRIPTION
The method `_assign_task_to_user` might be called via `recover_in_progress_tasks` in the `SecurityBot` constructor. `_assign_task_to_user` uses `self.test_username` however, it is only set after the call of `recover_in_progress_tasks`, thus this can result in an `AttributeError`.

Placing the setting of `test_username` before calling `recover_in_progress_tasks` should solve this.